### PR TITLE
Minor fixes

### DIFF
--- a/Application/src/main/java/com/example/android/common/media/CameraHelper.java
+++ b/Application/src/main/java/com/example/android/common/media/CameraHelper.java
@@ -36,49 +36,58 @@ public class CameraHelper {
     public static final int MEDIA_TYPE_VIDEO = 2;
 
     /**
-     * Iterate over supported camera preview sizes to see which one best fits the
+     * Iterate over supported camera video sizes to see which one best fits the
      * dimensions of the given view while maintaining the aspect ratio. If none can,
      * be lenient with the aspect ratio.
      *
-     * @param sizes Supported camera preview sizes.
-     * @param w The width of the view.
-     * @param h The height of the view.
-     * @return Best match camera preview size to fit in the view.
+     * @param supportedVideoSizes Supported camera video sizes.
+     * @param previewSizes Supported camera preview sizes.
+     * @param w     The width of the view.
+     * @param h     The height of the view.
+     * @return Best match camera video size to fit in the view.
      */
-    public static  Camera.Size getOptimalPreviewSize(List<Camera.Size> sizes, int w, int h) {
+    public static Camera.Size getOptimalVideoSize(List<Camera.Size> supportedVideoSizes,
+            List<Camera.Size> previewSizes, int w, int h) {
         // Use a very small tolerance because we want an exact match.
         final double ASPECT_TOLERANCE = 0.1;
         double targetRatio = (double) w / h;
-        if (sizes == null)
-            return null;
+
+        // Supported video sizes list might be null, it means that we are allowed to use the preview
+        // sizes
+        List<Camera.Size> videoSizes;
+        if (supportedVideoSizes != null) {
+            videoSizes = supportedVideoSizes;
+        } else {
+            videoSizes = previewSizes;
+        }
 
         Camera.Size optimalSize = null;
 
-        // Start with max value and refine as we iterate over available preview sizes. This is the
+        // Start with max value and refine as we iterate over available video sizes. This is the
         // minimum difference between view and camera height.
         double minDiff = Double.MAX_VALUE;
 
         // Target view height
         int targetHeight = h;
 
-        // Try to find a preview size that matches aspect ratio and the target view size.
+        // Try to find a video size that matches aspect ratio and the target view size.
         // Iterate over all available sizes and pick the largest size that can fit in the view and
         // still maintain the aspect ratio.
-        for (Camera.Size size : sizes) {
+        for (Camera.Size size : videoSizes) {
             double ratio = (double) size.width / size.height;
             if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE)
                 continue;
-            if (Math.abs(size.height - targetHeight) < minDiff) {
+            if (Math.abs(size.height - targetHeight) < minDiff && previewSizes.contains(size)) {
                 optimalSize = size;
                 minDiff = Math.abs(size.height - targetHeight);
             }
         }
 
-        // Cannot find preview size that matches the aspect ratio, ignore the requirement
+        // Cannot find video size that matches the aspect ratio, ignore the requirement
         if (optimalSize == null) {
             minDiff = Double.MAX_VALUE;
-            for (Camera.Size size : sizes) {
-                if (Math.abs(size.height - targetHeight) < minDiff) {
+            for (Camera.Size size : videoSizes) {
+                if (Math.abs(size.height - targetHeight) < minDiff && previewSizes.contains(size)) {
                     optimalSize = size;
                     minDiff = Math.abs(size.height - targetHeight);
                 }

--- a/Application/src/main/java/com/example/android/mediarecorder/MainActivity.java
+++ b/Application/src/main/java/com/example/android/mediarecorder/MainActivity.java
@@ -25,13 +25,13 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.Menu;
 import android.view.TextureView;
 import android.view.View;
 import android.widget.Button;
 
 import com.example.android.common.media.CameraHelper;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -45,6 +45,7 @@ public class MainActivity extends Activity {
     private Camera mCamera;
     private TextureView mPreview;
     private MediaRecorder mMediaRecorder;
+    private File mOutputFile;
 
     private boolean isRecording = false;
     private static final String TAG = "Recorder";
@@ -71,7 +72,15 @@ public class MainActivity extends Activity {
             // BEGIN_INCLUDE(stop_release_media_recorder)
 
             // stop recording and release camera
-            mMediaRecorder.stop();  // stop the recording
+            try {
+                mMediaRecorder.stop();  // stop the recording
+            } catch (RuntimeException e) {
+                // RuntimeException is thrown when stop() is called immediately after start().
+                // In this case the output file is not properly constructed ans should be deleted.
+                Log.d(TAG, "RuntimeException: stop() is called immediately after start()");
+                //noinspection ResultOfMethodCallIgnored
+                mOutputFile.delete();
+            }
             releaseMediaRecorder(); // release the MediaRecorder object
             mCamera.lock();         // take camera access back from MediaRecorder
 
@@ -137,8 +146,9 @@ public class MainActivity extends Activity {
         // dimensions of our preview surface.
         Camera.Parameters parameters = mCamera.getParameters();
         List<Camera.Size> mSupportedPreviewSizes = parameters.getSupportedPreviewSizes();
-        Camera.Size optimalSize = CameraHelper.getOptimalPreviewSize(mSupportedPreviewSizes,
-                mPreview.getWidth(), mPreview.getHeight());
+        List<Camera.Size> mSupportedVideoSizes = parameters.getSupportedVideoSizes();
+        Camera.Size optimalSize = CameraHelper.getOptimalVideoSize(mSupportedVideoSizes,
+                mSupportedPreviewSizes, mPreview.getWidth(), mPreview.getHeight());
 
         // Use the same size for recording profile.
         CamcorderProfile profile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
@@ -174,8 +184,11 @@ public class MainActivity extends Activity {
         mMediaRecorder.setProfile(profile);
 
         // Step 4: Set output file
-        mMediaRecorder.setOutputFile(CameraHelper.getOutputMediaFile(
-                CameraHelper.MEDIA_TYPE_VIDEO).toString());
+        mOutputFile = CameraHelper.getOutputMediaFile(CameraHelper.MEDIA_TYPE_VIDEO);
+        if (mOutputFile == null) {
+            return false;
+        }
+        mMediaRecorder.setOutputFile(mOutputFile.getPath());
         // END_INCLUDE (configure_media_recorder)
 
         // Step 5: Prepare configured MediaRecorder


### PR DESCRIPTION
Some devices may not support all the sizes from getSupportedPreviewSizes() list for video recording. For this purpose camera api has method getSupportedVideoSizes(). Also MediaRecorder.stop() can throw an exception (check the docs) that should be handled.
